### PR TITLE
refactor: switch default drivers from database to Redis for cache, queue and session

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_STORE', 'database'),
+    'default' => env('CACHE_STORE', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'database'),
+    'default' => env('QUEUE_CONNECTION', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/session.php
+++ b/config/session.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'database'),
+    'driver' => env('SESSION_DRIVER', 'redis'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION


- Update cache default driver from 'database' to 'redis' in config/cache.php
- Update queue default connection from 'database' to 'redis' in config/queue.php
- Update session default driver from 'database' to 'redis' in config/session.php

This change improves performance by leveraging Redis for caching, job queuing, and session management instead of database storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Default cache, queue, and session drivers now use Redis when environment variables aren’t set.
  - Users may experience faster page loads, more responsive background processing, and improved session handling under default settings.
  - Self-hosted deployments should ensure Redis is available to benefit from the new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->